### PR TITLE
fix(client): Sets Redis client max listeners to zero

### DIFF
--- a/lib/QueueManager.js
+++ b/lib/QueueManager.js
@@ -102,6 +102,7 @@ class QueueManager extends EventEmitter {
       debug('client:create');
       this._numClients++;
       this._client = new Redis(this._bullOpts.redis);
+      this._client.setMaxListeners(0);
     }
     return this._client;
   }
@@ -141,7 +142,9 @@ class QueueManager extends EventEmitter {
       default:
         this._numClients++;
         debug('new client', type, this._numClients);
-        return new Redis(redisOpts);
+        const redis = new Redis(redisOpts);
+        redis.setMaxListeners(0);
+        return redis;
     }
   }
 }


### PR DESCRIPTION
Prevents potential MaxListenersExceededWarning in environments where multiple event listeners might be attached to Redis client instances, ensuring smoother operation and avoiding unnecessary warnings.